### PR TITLE
Updated the Channel version & License details wrt CP4i 2021.4.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,4 @@
+## As of Feb/4/2022 this module resolve the dependency for CP4i version 2021.4.1
 locals {
   platform_navigator = {
     channel = "v5.2"


### PR DESCRIPTION
Signed-off-by: Cloud-Native Toolkit <cloudnativetoolkit@gmail.com>